### PR TITLE
Remove name from skyuxconfig.json

### DIFF
--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -1,5 +1,4 @@
 {
-  "name": "stache2template",
   "mode": "easy",
   "compileMode": "aot",
   "plugins": [


### PR DESCRIPTION
- Removing this so that all sites won't include `stache2template` in the URL.