### PR TITLE
Remove auth and add edit button

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "@blackbaud/skyux": "^2.0.1",
-    "@blackbaud/skyux-builder-plugin-auth-email-whitelist": "~1.0.0",
     "@blackbaud/stache": "^2.0.1"
   },
   "devDependencies": {

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -11,7 +11,7 @@
   "appSettings": {
     "stache": {
       "editButton": {
-        "url": "https://github.com/{your-repo-url}"
+        "url": "{your-repo-url}"
       }
     }
   }

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -1,16 +1,18 @@
 {
   "mode": "easy",
   "compileMode": "aot",
-  "auth": true,
+  "auth": false,
   "plugins": [
     "@blackbaud/skyux-builder-plugin-stache",
-    "@blackbaud/skyux-builder-plugin-auth-email-whitelist"
   ],
   "app": {
     "title": "Stache 2 Template"
   },
   "appSettings": {
     "stache": {
+      "editButton": {
+        "url": "https://github.com/{your-repo-url}"
+      }
     }
   }
 }

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -3,7 +3,7 @@
   "compileMode": "aot",
   "auth": false,
   "plugins": [
-    "@blackbaud/skyux-builder-plugin-stache",
+    "@blackbaud/skyux-builder-plugin-stache"
   ],
   "app": {
     "title": "Stache 2 Template"

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -11,7 +11,7 @@
   "appSettings": {
     "stache": {
       "editButton": {
-        "url": "{your-repo-url}"
+        "url": "your-repo-url"
       }
     }
   }


### PR DESCRIPTION
Auth is unnecessary for non-BB Stache SPAs. Added configuration for edit button to enable easier setup of the feature.